### PR TITLE
Encounter Building Challenge Estimation

### DIFF
--- a/src/components/Drawer/BaseCharacterDrawer/NPCDrawer/index.tsx
+++ b/src/components/Drawer/BaseCharacterDrawer/NPCDrawer/index.tsx
@@ -5,28 +5,30 @@ import CreateOrEditBaseCharacterDrawer from "..";
 import { useCreateNPC, useEditNPC } from "@services/NPCService";
 
 declare interface NPCDrawerProps extends DrawerProps {
-    editNPC?: BaseCharacter | null,
-    campaignDocId: string
+  editNPC?: BaseCharacter | null;
+  campaignDocId: string;
 }
 
 const NPCDrawer = ({
-    isOpen, onClose = () => {}, editNPC, campaignDocId
+  isOpen,
+  onClose = () => {},
+  editNPC,
+  campaignDocId,
 }: NPCDrawerProps) => {
+  const { mutate: create, isLoading: createLoading } = useCreateNPC(onClose);
+  const { mutate: edit, isLoading: editLoading } = useEditNPC(editNPC, onClose);
 
-    const { mutate: create, isLoading: createLoading } = useCreateNPC(onClose);
-    const { mutate: edit, isLoading: editLoading } = useEditNPC(editNPC, onClose);
+  return (
+    <CreateOrEditBaseCharacterDrawer
+      editCharacter={editNPC}
+      isOpen={isOpen}
+      onClose={onClose}
+      isNpc
+      edit={(npc: BaseCharacter) => edit({ ...npc, campaignDocId })}
+      create={(npc: BaseCharacter) => create({ ...npc, campaignDocId })}
+      isLoading={createLoading || editLoading}
+    />
+  );
+};
 
-    return (
-        <CreateOrEditBaseCharacterDrawer
-            editCharacter={editNPC}
-            isOpen={isOpen}
-            onClose={onClose}
-            edit={(npc: BaseCharacter) => edit({...npc, campaignDocId})}
-            create={(npc: BaseCharacter) => create({...npc, campaignDocId})}
-            isLoading={createLoading || editLoading}
-        />
-    );
-
-}
-
-export default NPCDrawer
+export default NPCDrawer;

--- a/src/components/Drawer/BaseCharacterDrawer/index.tsx
+++ b/src/components/Drawer/BaseCharacterDrawer/index.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from "react";
 import Drawer, { DrawerProps } from "..";
-import { BASE_ABILITY_SCORES, BaseCharacter, CharacterSizes, CharacterType, SavingThrow } from "@model/BaseCharacter";
-import css from "./BaseCharacterDrawer.module.scss"
+import {
+  BASE_ABILITY_SCORES,
+  BaseCharacter,
+  CharacterSizes,
+  CharacterType,
+  SavingThrow,
+} from "@model/BaseCharacter";
+import css from "./BaseCharacterDrawer.module.scss";
 import { Grid } from "@mui/material";
 import { TextInput } from "@components/TextInput/TextInput";
 import SizeSelect from "@components/Selects/SizeSelect";
@@ -17,148 +23,362 @@ import { calculateAbilityScoreModifier } from "./utils";
 import { faXmarkCircle } from "@fortawesome/free-regular-svg-icons";
 
 declare interface BaseCharacterProps extends DrawerProps {
-    editCharacter?: BaseCharacter | null;
-    edit: (character: BaseCharacter) => void;
-    create: (character: BaseCharacter) => void;
-    isLoading?: boolean
+  editCharacter?: BaseCharacter | null;
+  edit: (character: BaseCharacter) => void;
+  create: (character: BaseCharacter) => void;
+  isLoading?: boolean;
+  isNpc?: boolean;
 }
 
-const BaseCharacterDrawer = ({isOpen, onClose = () => {}, editCharacter, edit, create, isLoading = false}: BaseCharacterProps) => {
-    const [character, setCharacter] = useState<BaseCharacter>({docId: "", name: "", abilityScores: BASE_ABILITY_SCORES});
+const BaseCharacterDrawer = ({
+  isOpen,
+  onClose = () => {},
+  editCharacter,
+  edit,
+  create,
+  isLoading = false,
+  isNpc = false,
+}: BaseCharacterProps) => {
+  const [character, setCharacter] = useState<BaseCharacter>({
+    docId: "",
+    name: "",
+    abilityScores: BASE_ABILITY_SCORES,
+  });
 
-    useEffect(() => {
-        setCharacter(editCharacter || {docId: "", name: "", abilityScores: BASE_ABILITY_SCORES})
-    }, [isOpen])
+  useEffect(() => {
+    setCharacter(
+      editCharacter || {
+        docId: "",
+        name: "",
+        abilityScores: BASE_ABILITY_SCORES,
+      },
+    );
+  }, [isOpen]);
 
-    return (
-        <Drawer
-            side="bottom"
-            isOpen={isOpen}
-            onClose={onClose}
-        >
-            <div className={css.characterDrawer}>
-                <Grid container justifyContent="end" spacing={2}>
-                <Grid item>
-                        <LoadingButton
-                            color="success"
-                            isLoading={isLoading}
-                            onClick={() => {
-                                editCharacter ? edit(character) : create(character)
-                            }}
-                        >
-                            <Typography size="large" color="dark">Submit</Typography>
-                        </LoadingButton>
-                    </Grid>
-                    <Grid item>
-                        <Button color="dark" borderColor="light" onClick={onClose}><Typography color="light" size="large"><FontAwesomeIcon icon={faXmarkCircle}/></Typography></Button>
-                    </Grid>
-                </Grid>
-                <Grid container spacing={2} rowGap={2}>
-                    <Grid item xs={12} md={6}>
-                        <TextInput value={character?.name} onChange={(value) => setCharacter({ ...character, name: String(value)})} placeholder='Name' />
-                    </Grid>
-                    <Grid item xs={12} md={3}>
-                        <SizeSelect value={character.size} onChange={(value: CharacterSizes) => setCharacter({ ...character, size: value})} />
-                    </Grid>
-                    <Grid item xs={12} md={3}>
-                        <CharacterTypeSelect value={character.type} onChange={(value: CharacterType) => setCharacter({ ...character, type: value})} />
-                    </Grid>
-                    <Grid item xs={12} md={4}>
-                        <TextInput value={character?.characterImageURL} onChange={(value) => setCharacter({ ...character, characterImageURL: String(value)})} placeholder='Image URL' />
-                    </Grid>
-                    
-                    <Grid item xs={12} md={2}>
-                        <TextInput value={character?.averageHitPoints} onChange={(value) => setCharacter({ ...character, averageHitPoints: Number(value)})} placeholder='Average Hit Points' number />
-                    </Grid>
-                    <Grid item xs={4} md={2}>
-                        <TextInput value={character?.speed} onChange={(value) => setCharacter({ ...character, speed: Number(value)})} placeholder='Speed' number />
-                    </Grid>
-                    <Grid item xs={4} md={2}>
-                        <TextInput value={character?.armorClass} onChange={(value) => setCharacter({ ...character, armorClass: Number(value)})} placeholder='Armor Class' number />
-                    </Grid>
-                    <Grid item xs={4} md={2}>
-                        <TextInput value={character?.passivePerception} onChange={(value) => setCharacter({ ...character, passivePerception: Number(value)})} placeholder='Passive Percep' number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.strength} onChange={(value) => {
-                            const scores = {...character?.abilityScores, strength: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Strength (${calculateAbilityScoreModifier(character?.abilityScores.strength)})`} number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.dexterity} onChange={(value) => {
-                            const scores = {...character?.abilityScores, dexterity: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Dexterity (${calculateAbilityScoreModifier(character?.abilityScores.dexterity)})`} number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.constitution} onChange={(value) => {
-                            const scores = {...character?.abilityScores, constitution: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Constitution ${calculateAbilityScoreModifier(character?.abilityScores.constitution)}`} number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.intelligence} onChange={(value) => {
-                            const scores = {...character?.abilityScores, intelligence: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Intelligence (${calculateAbilityScoreModifier(character?.abilityScores.intelligence)})`} number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.wisdom} onChange={(value) => {
-                            const scores = {...character?.abilityScores, wisdom: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Wisdom (${calculateAbilityScoreModifier(character?.abilityScores.wisdom)})`} number />
-                    </Grid>
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.abilityScores?.charisma} onChange={(value) => {
-                            const scores = {...character?.abilityScores, charisma: Number(value)}
-                            setCharacter({...character, abilityScores: scores})
-                        }} placeholder={`Charisma (${calculateAbilityScoreModifier(character?.abilityScores.charisma)})`} number />
-                    </Grid>
+  return (
+    <Drawer side="bottom" isOpen={isOpen} onClose={onClose}>
+      <div className={css.characterDrawer}>
+        <Grid container justifyContent="end" spacing={2}>
+          <Grid item>
+            <LoadingButton
+              color="success"
+              isLoading={isLoading}
+              onClick={() => {
+                editCharacter ? edit(character) : create(character);
+              }}
+            >
+              <Typography size="large" color="dark">
+                Submit
+              </Typography>
+            </LoadingButton>
+          </Grid>
+          <Grid item>
+            <Button color="dark" borderColor="light" onClick={onClose}>
+              <Typography color="light" size="large">
+                <FontAwesomeIcon icon={faXmarkCircle} />
+              </Typography>
+            </Button>
+          </Grid>
+        </Grid>
+        <Grid container spacing={2} rowGap={2}>
+          <Grid item xs={12} md={6}>
+            <TextInput
+              value={character?.name}
+              onChange={(value) =>
+                setCharacter({ ...character, name: String(value) })
+              }
+              placeholder="Name"
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <SizeSelect
+              value={character.size}
+              onChange={(value: CharacterSizes) =>
+                setCharacter({ ...character, size: value })
+              }
+            />
+          </Grid>
+          <Grid item xs={12} md={3}>
+            <CharacterTypeSelect
+              value={character.type}
+              onChange={(value: CharacterType) =>
+                setCharacter({ ...character, type: value })
+              }
+            />
+          </Grid>
+          <Grid item xs={12} md={2}>
+            <TextInput
+              value={character?.characterImageURL}
+              onChange={(value) =>
+                setCharacter({ ...character, characterImageURL: String(value) })
+              }
+              placeholder="Image URL"
+            />
+          </Grid>
 
-                    <Grid item xs={12} md={2}>
-                        <SavingThrowSelect value={character.savingThrowProficiencies || []} onChange={(value: SavingThrow[]) => setCharacter({ ...character, savingThrowProficiencies: value})} />
-                    </Grid>
+          <Grid item xs={12} md={2}>
+            <TextInput
+              value={character?.averageHitPoints}
+              onChange={(value) =>
+                setCharacter({ ...character, averageHitPoints: Number(value) })
+              }
+              placeholder="Average Hit Points"
+              number
+            />
+          </Grid>
+          <Grid item xs={12} md={2}>
+            {isNpc ? (
+              <TextInput
+                value={character?.level ?? 1}
+                onChange={(value) =>
+                  setCharacter({ ...character, level: Number(value) })
+                }
+                placeholder="Level"
+                number
+              />
+            ) : (
+              <TextInput
+                value={character?.xp ?? 0}
+                onChange={(value) =>
+                  setCharacter({ ...character, xp: Number(value) })
+                }
+                placeholder="XP"
+                number
+              />
+            )}
+          </Grid>
+          <Grid item xs={4} md={2}>
+            <TextInput
+              value={character?.speed}
+              onChange={(value) =>
+                setCharacter({ ...character, speed: Number(value) })
+              }
+              placeholder="Speed"
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={2}>
+            <TextInput
+              value={character?.armorClass}
+              onChange={(value) =>
+                setCharacter({ ...character, armorClass: Number(value) })
+              }
+              placeholder="Armor Class"
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={2}>
+            <TextInput
+              value={character?.passivePerception}
+              onChange={(value) =>
+                setCharacter({ ...character, passivePerception: Number(value) })
+              }
+              placeholder="Passive Percep"
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.strength}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  strength: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Strength (${calculateAbilityScoreModifier(
+                character?.abilityScores.strength,
+              )})`}
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.dexterity}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  dexterity: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Dexterity (${calculateAbilityScoreModifier(
+                character?.abilityScores.dexterity,
+              )})`}
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.constitution}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  constitution: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Constitution ${calculateAbilityScoreModifier(
+                character?.abilityScores.constitution,
+              )}`}
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.intelligence}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  intelligence: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Intelligence (${calculateAbilityScoreModifier(
+                character?.abilityScores.intelligence,
+              )})`}
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.wisdom}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  wisdom: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Wisdom (${calculateAbilityScoreModifier(
+                character?.abilityScores.wisdom,
+              )})`}
+              number
+            />
+          </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.abilityScores?.charisma}
+              onChange={(value) => {
+                const scores = {
+                  ...character?.abilityScores,
+                  charisma: Number(value),
+                };
+                setCharacter({ ...character, abilityScores: scores });
+              }}
+              placeholder={`Charisma (${calculateAbilityScoreModifier(
+                character?.abilityScores.charisma,
+              )})`}
+              number
+            />
+          </Grid>
 
-                    <Grid item xs={4} md={1}>
-                        <TextInput value={character?.proficiencyBonus} onChange={(value) => setCharacter({ ...character, proficiencyBonus: Number(value)})} placeholder='Prof. Bonus' number />
-                    </Grid>
+          <Grid item xs={12} md={2}>
+            <SavingThrowSelect
+              value={character.savingThrowProficiencies || []}
+              onChange={(value: SavingThrow[]) =>
+                setCharacter({ ...character, savingThrowProficiencies: value })
+              }
+            />
+          </Grid>
 
-                    <Grid item xs={12} md={3}>
-                        <SkillsSelect value={character.skillProficiencies || []} onChange={(value: SavingThrow[]) => setCharacter({ ...character, skillProficiencies: value})} />
-                    </Grid>
+          <Grid item xs={4} md={1}>
+            <TextInput
+              value={character?.proficiencyBonus}
+              onChange={(value) =>
+                setCharacter({ ...character, proficiencyBonus: Number(value) })
+              }
+              placeholder="Prof. Bonus"
+              number
+            />
+          </Grid>
 
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Description</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.description || ""} onChange={(value) => setCharacter({ ...character, description: String(value)})} placeholder='Description' />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Actions</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.actions || ""} onChange={(value) => setCharacter({ ...character, actions: String(value)})} placeholder='Actions' />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Bonus Actions</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.bonusActions || ""} onChange={(value) => setCharacter({ ...character, bonusActions: String(value)})} placeholder='Bonus Actions' />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Reactions</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.reactions || ""} onChange={(value) => setCharacter({ ...character, reactions: String(value)})} placeholder='Reactions' />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Legendary Actions</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.legendaryActions || ""} onChange={(value) => setCharacter({ ...character, legendaryActions: String(value)})} placeholder='Legendary Actions' />
-                    </Grid>
-                    <Grid item xs={12} md={6}>
-                        <Typography color="primary">Lair Actions</Typography>
-                        <TextEditor height={400} preview="edit" value={character?.lairActions || ""} onChange={(value) => setCharacter({ ...character, lairActions: String(value)})} placeholder='Lair Actions' />
-                    </Grid>
-                </Grid>
-                
-            </div>
-           
-        </Drawer>
-    )
+          <Grid item xs={12} md={3}>
+            <SkillsSelect
+              value={character.skillProficiencies || []}
+              onChange={(value: SavingThrow[]) =>
+                setCharacter({ ...character, skillProficiencies: value })
+              }
+            />
+          </Grid>
 
-}
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Description</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.description || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, description: String(value) })
+              }
+              placeholder="Description"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Actions</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.actions || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, actions: String(value) })
+              }
+              placeholder="Actions"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Bonus Actions</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.bonusActions || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, bonusActions: String(value) })
+              }
+              placeholder="Bonus Actions"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Reactions</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.reactions || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, reactions: String(value) })
+              }
+              placeholder="Reactions"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Legendary Actions</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.legendaryActions || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, legendaryActions: String(value) })
+              }
+              placeholder="Legendary Actions"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Typography color="primary">Lair Actions</Typography>
+            <TextEditor
+              height={400}
+              preview="edit"
+              value={character?.lairActions || ""}
+              onChange={(value) =>
+                setCharacter({ ...character, lairActions: String(value) })
+              }
+              placeholder="Lair Actions"
+            />
+          </Grid>
+        </Grid>
+      </div>
+    </Drawer>
+  );
+};
 
 export default BaseCharacterDrawer;

--- a/src/components/Modal/CreateCharacterModal/CreateCharacterModal.tsx
+++ b/src/components/Modal/CreateCharacterModal/CreateCharacterModal.tsx
@@ -1,90 +1,228 @@
-import React, {useState} from 'react';
-import { Modal } from '../Modal';
-import { Grid } from '@mui/material';
-import { TextInput } from '../../TextInput/TextInput';
-import CampaignPicker from '../../CampaignPicker/CampaignPicker';
-import ClassPicker from '../../ClassPicker/ClassPicker';
-import TextArea from '../../TextArea/TextArea';
+import React, { useState } from "react";
+import { Modal } from "../Modal";
+import { Grid } from "@mui/material";
+import { TextInput } from "../../TextInput/TextInput";
+import CampaignPicker from "../../CampaignPicker/CampaignPicker";
+import ClassPicker from "../../ClassPicker/ClassPicker";
+import TextArea from "../../TextArea/TextArea";
 
-import css from "./CreateCharacterModal.module.scss"
-import { Character, validateCharacter } from '@model/Character';
-import { useAddCharacterButton, useUpdateCharacterButton } from '@services/CharacterService';
-import useDeepCompareEffect from 'use-deep-compare-effect';
+import css from "./CreateCharacterModal.module.scss";
+import { Character, validateCharacter } from "@model/Character";
+import {
+  useAddCharacterButton,
+  useUpdateCharacterButton,
+} from "@services/CharacterService";
+import useDeepCompareEffect from "use-deep-compare-effect";
 
 declare interface CreateCharacterModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-    initialCampaignId?: string,
-    character?: Character
-    
-};
-
-const CreateCharacterModal = ({isOpen, onClose, initialCampaignId, character = new Character(null, "", initialCampaignId)}: CreateCharacterModalProps) => {
-    const [newCharacter, setNewCharacter] = useState<Character>(character);
-    const [validator, setValidator] = useState<any>();
-    const [campaign, setCampaign] = useState();
-    const saveCharacterButton = useAddCharacterButton(newCharacter, () => handleOnClose(), () => validate());
-    const updateCharacterButton = useUpdateCharacterButton(newCharacter, () => handleOnClose(), () => validate());
-    const { name, player, characterImageURL, backstory, className, dndBeyondURL, passivePerception, initiativeBonus, armorClass, maxHealth } = newCharacter;
-
-    const validate = () => {
-        const valid = validateCharacter(newCharacter)
-        setValidator(valid)
-
-        return !(Object.keys(valid).length > 0);
-    }
-
-    useDeepCompareEffect(() => {
-        setNewCharacter(character)
-    }, [character, isOpen])
-
-    const handleOnClose = () => {
-            onClose();
-    }
-
-    return (
-        <div>
-            <Modal isOpen={isOpen} onClose={handleOnClose} extraButtons={[
-                character.docId ? updateCharacterButton : saveCharacterButton
-                ]}>
-                <Grid container spacing={2} rowSpacing={3} className={css.CreateCharacterModal}>
-                    <Grid item lg={6} sm={12}>
-                        <TextInput error={validator?.name} value={name} onChange={value => setNewCharacter({ ...newCharacter, name: value,})} placeholder='Name' />
-                    </Grid>
-                    <Grid item lg={6} sm={12}>
-                        <TextInput error={validator?.player} value={player} onChange={value => setNewCharacter({ ...newCharacter, player: String(value),})} placeholder='Player' />
-                    </Grid>
-                    <Grid item lg={6} sm={12}>
-                        <TextInput error={validator?.characterImageURL} value={characterImageURL} onChange={value => setNewCharacter({ ...newCharacter, characterImageURL: value,})} placeholder='Character Image Url' />
-                    </Grid>
-                    <Grid item lg={6} sm={12}>
-                        <TextInput error={validator?.dndBeyondURL} value={dndBeyondURL} onChange={value => setNewCharacter({ ...newCharacter, dndBeyondURL: String(value),})} placeholder='DnD Beyond Url' />
-                    </Grid>
-                    <Grid item lg={4} sm={12}>
-                        <CampaignPicker initialCampaignId={initialCampaignId} value={campaign} onChange={(campaign) => { setNewCharacter({ ...newCharacter, campaignDocId: campaign.docId}); setCampaign(campaign)}} />
-                    </Grid>
-                    <Grid item lg={4} sm={12}>
-                        <ClassPicker value={className} onChange={(value) => setNewCharacter({ ...newCharacter, className: value,})} />
-                    </Grid>
-                    <Grid item lg={1} sm={6}>
-                        <TextInput number value={initiativeBonus} onChange={(value) => setNewCharacter({...newCharacter, initiativeBonus: Number(value)})} placeholder='Initiative Bonus' />
-                    </Grid>
-                    <Grid item lg={1} sm={6}>
-                        <TextInput number value={passivePerception} onChange={(value) => setNewCharacter({...newCharacter, passivePerception: Number(value || 0)})} placeholder='Passive Percep.' />
-                    </Grid>
-                    <Grid item lg={1} sm={6}>
-                        <TextInput number value={armorClass} onChange={(value) => setNewCharacter({...newCharacter, armorClass: Number(value || 0)})} placeholder='AC' />
-                    </Grid>
-                    <Grid item lg={1} sm={6}>
-                        <TextInput number value={maxHealth} onChange={(value) => setNewCharacter({...newCharacter, maxHealth: Number(value || 0)})} placeholder='Max Health' />
-                    </Grid>
-                    <Grid item sm={12}>
-                        <TextArea value={backstory} onChange={(value) => setNewCharacter({ ...newCharacter, backstory: value,})} rows={5} />
-                    </Grid>
-                </Grid>
-            </Modal>
-        </div>
-    );
+  isOpen: boolean;
+  onClose: () => void;
+  initialCampaignId?: string;
+  character?: Character;
 }
+
+const CreateCharacterModal = ({
+  isOpen,
+  onClose,
+  initialCampaignId,
+  character = new Character(null, "", initialCampaignId),
+}: CreateCharacterModalProps) => {
+  const [newCharacter, setNewCharacter] = useState<Character>(character);
+  const [validator, setValidator] = useState<any>();
+  const [campaign, setCampaign] = useState();
+  const saveCharacterButton = useAddCharacterButton(
+    newCharacter,
+    () => handleOnClose(),
+    () => validate(),
+  );
+  const updateCharacterButton = useUpdateCharacterButton(
+    newCharacter,
+    () => handleOnClose(),
+    () => validate(),
+  );
+  const {
+    name,
+    player,
+    characterImageURL,
+    backstory,
+    className,
+    dndBeyondURL,
+    passivePerception,
+    initiativeBonus,
+    armorClass,
+    maxHealth,
+    level,
+  } = newCharacter;
+
+  const validate = () => {
+    const valid = validateCharacter(newCharacter);
+    setValidator(valid);
+
+    return !(Object.keys(valid).length > 0);
+  };
+
+  useDeepCompareEffect(() => {
+    setNewCharacter(character);
+  }, [character, isOpen]);
+
+  const handleOnClose = () => {
+    onClose();
+  };
+
+  return (
+    <div>
+      <Modal
+        isOpen={isOpen}
+        onClose={handleOnClose}
+        extraButtons={[
+          character.docId ? updateCharacterButton : saveCharacterButton,
+        ]}
+      >
+        <Grid
+          container
+          spacing={2}
+          rowSpacing={3}
+          className={css.CreateCharacterModal}
+        >
+          <Grid item lg={6} sm={12}>
+            <TextInput
+              error={validator?.name}
+              value={name}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, name: value })
+              }
+              placeholder="Name"
+            />
+          </Grid>
+          <Grid item lg={6} sm={12}>
+            <TextInput
+              error={validator?.player}
+              value={player}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, player: String(value) })
+              }
+              placeholder="Player"
+            />
+          </Grid>
+          <Grid item lg={6} sm={12}>
+            <TextInput
+              error={validator?.characterImageURL}
+              value={characterImageURL}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, characterImageURL: value })
+              }
+              placeholder="Character Image Url"
+            />
+          </Grid>
+          <Grid item lg={6} sm={12}>
+            <TextInput
+              error={validator?.dndBeyondURL}
+              value={dndBeyondURL}
+              onChange={(value) =>
+                setNewCharacter({
+                  ...newCharacter,
+                  dndBeyondURL: String(value),
+                })
+              }
+              placeholder="DnD Beyond Url"
+            />
+          </Grid>
+          <Grid item lg={4} sm={12}>
+            <CampaignPicker
+              initialCampaignId={initialCampaignId}
+              value={campaign}
+              onChange={(campaign) => {
+                setNewCharacter({
+                  ...newCharacter,
+                  campaignDocId: campaign.docId,
+                });
+                setCampaign(campaign);
+              }}
+            />
+          </Grid>
+          <Grid item lg={4} sm={12}>
+            <ClassPicker
+              value={className}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, className: value })
+              }
+            />
+          </Grid>
+          <Grid item lg={1} sm={6}>
+            <TextInput
+              number
+              value={level}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, level: Number(value) })
+              }
+              placeholder="Level"
+            />
+          </Grid>
+          <Grid item lg={1} sm={6}>
+            <TextInput
+              number
+              value={initiativeBonus}
+              onChange={(value) =>
+                setNewCharacter({
+                  ...newCharacter,
+                  initiativeBonus: Number(value),
+                })
+              }
+              placeholder="Initiative Bonus"
+            />
+          </Grid>
+          <Grid item lg={1} sm={6}>
+            <TextInput
+              number
+              value={passivePerception}
+              onChange={(value) =>
+                setNewCharacter({
+                  ...newCharacter,
+                  passivePerception: Number(value || 0),
+                })
+              }
+              placeholder="Passive Percep."
+            />
+          </Grid>
+          <Grid item lg={1} sm={6}>
+            <TextInput
+              number
+              value={armorClass}
+              onChange={(value) =>
+                setNewCharacter({
+                  ...newCharacter,
+                  armorClass: Number(value || 0),
+                })
+              }
+              placeholder="AC"
+            />
+          </Grid>
+          <Grid item lg={1} sm={6}>
+            <TextInput
+              number
+              value={maxHealth}
+              onChange={(value) =>
+                setNewCharacter({
+                  ...newCharacter,
+                  maxHealth: Number(value || 0),
+                })
+              }
+              placeholder="Max Health"
+            />
+          </Grid>
+          <Grid item sm={12}>
+            <TextArea
+              value={backstory}
+              onChange={(value) =>
+                setNewCharacter({ ...newCharacter, backstory: value })
+              }
+              rows={5}
+            />
+          </Grid>
+        </Grid>
+      </Modal>
+    </div>
+  );
+};
 
 export default CreateCharacterModal;

--- a/src/model/BaseCharacter.ts
+++ b/src/model/BaseCharacter.ts
@@ -1,106 +1,109 @@
 export type AbilityScores = {
-    strength: number;
-    dexterity: number;
-    constitution: number;
-    intelligence: number;
-    wisdom: number;
-    charisma: number;
+  strength: number;
+  dexterity: number;
+  constitution: number;
+  intelligence: number;
+  wisdom: number;
+  charisma: number;
 };
 
 export type SavingThrow =
-    | "Strength"
-    | "Dexterity"
-    | "Constitution"
-    | "Intelligence"
-    | "Wisdom"
-    | "Charisma";
+  | "Strength"
+  | "Dexterity"
+  | "Constitution"
+  | "Intelligence"
+  | "Wisdom"
+  | "Charisma";
 
 export const BASE_ABILITY_SCORES = {
-    strength: 10,
-    dexterity: 10,
-    constitution: 10,
-    intelligence: 10,
-    wisdom: 10,
-    charisma: 10,
+  strength: 10,
+  dexterity: 10,
+  constitution: 10,
+  intelligence: 10,
+  wisdom: 10,
+  charisma: 10,
 };
 
 export type SkillProficiency = {
-    name: string;
-    bonus: number;
+  name: string;
+  bonus: number;
 };
 
 export type CharacterAction = {
-    name: string;
-    description: string;
+  name: string;
+  description: string;
 };
 
 export type CharacterSizes =
-    | "Tiny"
-    | "Small"
-    | "Medium"
-    | "Large"
-    | "Huge"
-    | "Gargantuan";
+  | "Tiny"
+  | "Small"
+  | "Medium"
+  | "Large"
+  | "Huge"
+  | "Gargantuan";
 
 export type CharacterType =
-    | "Aberration"
-    | "Animal"
-    | "Beast"
-    | "Celestial"
-    | "Construct"
-    | "Dragon"
-    | "Elemental"
-    | "Fey"
-    | "Fiend"
-    | "Giant"
-    | "Humanoid"
-    | "Magical Beast"
-    | "Monstrosity"
-    | "Ooze"
-    | "Plant"
-    | "Undead"
-    | "Unknown";
+  | "Aberration"
+  | "Animal"
+  | "Beast"
+  | "Celestial"
+  | "Construct"
+  | "Dragon"
+  | "Elemental"
+  | "Fey"
+  | "Fiend"
+  | "Giant"
+  | "Humanoid"
+  | "Magical Beast"
+  | "Monstrosity"
+  | "Ooze"
+  | "Plant"
+  | "Undead"
+  | "Unknown";
 export type CharacterTypeLowercase =
-    | "aberration"
-    | "animal"
-    | "beast"
-    | "celestial"
-    | "construct"
-    | "dragon"
-    | "elemental"
-    | "fey"
-    | "fiend"
-    | "giant"
-    | "humanoid"
-    | "magical beast"
-    | "monstrosity"
-    | "ooze"
-    | "plant"
-    | "undead"
-    | "unknown";
+  | "aberration"
+  | "animal"
+  | "beast"
+  | "celestial"
+  | "construct"
+  | "dragon"
+  | "elemental"
+  | "fey"
+  | "fiend"
+  | "giant"
+  | "humanoid"
+  | "magical beast"
+  | "monstrosity"
+  | "ooze"
+  | "plant"
+  | "undead"
+  | "unknown";
 
 export type BaseCharacter = {
-    docId?: string;
-    campaignDocId?: string;
-    name: string;
-    description?: string;
-    backstory?: string;
-    size?: CharacterSizes;
-    type?: CharacterType;
-    characterImageURL?: string;
-    abilityScores: AbilityScores;
-    armorClass?: number;
-    savingThrowProficiencies?: SavingThrow[];
-    averageHitPoints?: number;
-    passivePerception?: number;
-    skillProficiencies?: string[];
-    proficiencyBonus?: number;
-    speed?: number;
-    actions?: string;
-    bonusActions?: string;
-    reactions?: string;
-    lairActions?: string;
-    legendaryActions?: string;
-    otherActions?: string;
-    xp?: number;
+  docId?: string;
+  campaignDocId?: string;
+  name: string;
+  description?: string;
+  backstory?: string;
+  size?: CharacterSizes;
+  type?: CharacterType;
+  characterImageURL?: string;
+  abilityScores: AbilityScores;
+  armorClass?: number;
+  savingThrowProficiencies?: SavingThrow[];
+  averageHitPoints?: number;
+  passivePerception?: number;
+  skillProficiencies?: string[];
+  proficiencyBonus?: number;
+  speed?: number;
+  actions?: string;
+  bonusActions?: string;
+  reactions?: string;
+  lairActions?: string;
+  legendaryActions?: string;
+  otherActions?: string;
+  // Only applies to custom monsters.
+  xp?: number;
+  // Only applies to npcs.
+  level?: number;
 };

--- a/src/model/BaseCharacter.ts
+++ b/src/model/BaseCharacter.ts
@@ -1,13 +1,19 @@
 export type AbilityScores = {
-    strength: number,
-    dexterity: number,
-    constitution: number,
-    intelligence: number,
-    wisdom: number,
-    charisma: number
+    strength: number;
+    dexterity: number;
+    constitution: number;
+    intelligence: number;
+    wisdom: number;
+    charisma: number;
 };
 
-export type SavingThrow = "Strength" | "Dexterity" | "Constitution" | "Intelligence" | "Wisdom" | "Charisma";
+export type SavingThrow =
+    | "Strength"
+    | "Dexterity"
+    | "Constitution"
+    | "Intelligence"
+    | "Wisdom"
+    | "Charisma";
 
 export const BASE_ABILITY_SCORES = {
     strength: 10,
@@ -15,23 +21,63 @@ export const BASE_ABILITY_SCORES = {
     constitution: 10,
     intelligence: 10,
     wisdom: 10,
-    charisma: 10
+    charisma: 10,
 };
 
 export type SkillProficiency = {
-    name: string,
-    bonus: number,
+    name: string;
+    bonus: number;
 };
 
 export type CharacterAction = {
-    name: string,
-    description: string
+    name: string;
+    description: string;
 };
 
-export type CharacterSizes = "Tiny" | "Small" | "Medium" | "Large" | "Huge" | "Gargantuan";
+export type CharacterSizes =
+    | "Tiny"
+    | "Small"
+    | "Medium"
+    | "Large"
+    | "Huge"
+    | "Gargantuan";
 
-export type CharacterType = "Aberration" | "Animal" | "Beast" | "Celestial" | "Construct" | "Dragon" | "Elemental" | "Fey" | "Fiend" | "Giant" | "Humanoid" | "Magical Beast" | "Monstrosity" | "Ooze" | "Plant" | "Undead" | "Unknown"
-export type CharacterTypeLowercase = "aberration" | "animal" | "beast" | "celestial" | "construct" | "dragon" | "elemental" | "fey" | "fiend" | "giant" | "humanoid" | "magical beast" | "monstrosity" | "ooze" | "plant" | "undead" | "unknown"
+export type CharacterType =
+    | "Aberration"
+    | "Animal"
+    | "Beast"
+    | "Celestial"
+    | "Construct"
+    | "Dragon"
+    | "Elemental"
+    | "Fey"
+    | "Fiend"
+    | "Giant"
+    | "Humanoid"
+    | "Magical Beast"
+    | "Monstrosity"
+    | "Ooze"
+    | "Plant"
+    | "Undead"
+    | "Unknown";
+export type CharacterTypeLowercase =
+    | "aberration"
+    | "animal"
+    | "beast"
+    | "celestial"
+    | "construct"
+    | "dragon"
+    | "elemental"
+    | "fey"
+    | "fiend"
+    | "giant"
+    | "humanoid"
+    | "magical beast"
+    | "monstrosity"
+    | "ooze"
+    | "plant"
+    | "undead"
+    | "unknown";
 
 export type BaseCharacter = {
     docId?: string;
@@ -56,4 +102,5 @@ export type BaseCharacter = {
     lairActions?: string;
     legendaryActions?: string;
     otherActions?: string;
+    xp?: number;
 };

--- a/src/model/ChallengeRating.ts
+++ b/src/model/ChallengeRating.ts
@@ -6,7 +6,7 @@ type Tuple<
 > = R["length"] extends N ? R : Tuple<T, N, readonly [T, ...R]>;
 
 type CharacterXpThresholdsByLevel = Tuple<number, 20>;
-enum DIFFICULTY {
+export enum ENCOUNTER_DIFFICULTY {
   easy,
   medium,
   hard,
@@ -15,7 +15,7 @@ enum DIFFICULTY {
 
 // TODO (churt): Maybe there is a formula? But the pattern didn't suggest it.
 export const CharacterLevelEncounterXpThresholdsByDiffulty: Record<
-  keyof typeof DIFFICULTY,
+  keyof typeof ENCOUNTER_DIFFICULTY,
   CharacterXpThresholdsByLevel
 > = {
   easy: [
@@ -34,4 +34,66 @@ export const CharacterLevelEncounterXpThresholdsByDiffulty: Record<
     100, 200, 400, 500, 1100, 1400, 1700, 2100, 2400, 2800, 3600, 4500, 5100,
     5700, 6400, 7200, 8800, 9500, 10900, 12700,
   ],
+};
+
+const EncounterMultipliers = [1, 1.5, 2, 2.5, 3, 5];
+
+export const getEncounterMultiplier = (
+  monsterCount: number,
+  playerCount: number,
+): number => {
+  let multiplierIndex = 0;
+
+  if (monsterCount === 2) {
+    multiplierIndex = 1;
+  }
+
+  if (monsterCount >= 3 && monsterCount <= 6) {
+    multiplierIndex = 2;
+  }
+
+  if (monsterCount >= 7 && monsterCount <= 10) {
+    multiplierIndex = 3;
+  }
+
+  if (monsterCount >= 11 && monsterCount <= 14) {
+    multiplierIndex = 4;
+  }
+
+  if (monsterCount > 15) {
+    multiplierIndex = 5;
+  }
+
+  if (playerCount < 3 && multiplierIndex < 5) {
+    multiplierIndex += 1;
+  }
+
+  if (playerCount > 6) {
+    // Special case for large parties and a single monster.
+    if (monsterCount === 1) {
+      return 0.5;
+    }
+
+    multiplierIndex -= 1;
+  }
+
+  return EncounterMultipliers[multiplierIndex];
+};
+
+export const getEncounterDifficulty = (
+  monstersXp: number[],
+  playersXp: number[],
+): ENCOUNTER_DIFFICULTY => {
+  const playerBudget = playersXp.reduce(
+    (accumulator, currentValue) => accumulator + currentValue,
+  );
+
+  const currentMonsterCost = monstersXp.reduce(
+    (accumulator, currentValue) => accumulator + currentValue,
+  );
+
+  const encounterMultipler = getEncounterMultiplier(
+    monstersXp.length,
+    playersXp.length,
+  );
 };

--- a/src/model/ChallengeRating.ts
+++ b/src/model/ChallengeRating.ts
@@ -39,6 +39,44 @@ export const CharacterLevelEncounterXpThresholdsByDiffulty: Record<
   ],
 };
 
+// https://www.dndbeyond.com/sources/basic-rules/monsters#ExperiencePointsbyChallengeRating
+export const MonsterXPByChallengeRating: Record<number, number> = {
+  0: 0,
+  0.125: 25,
+  0.25: 50,
+  0.5: 100,
+  1: 200,
+  2: 450,
+  3: 700,
+  4: 1100,
+  5: 1800,
+  6: 2300,
+  7: 2900,
+  8: 3900,
+  9: 5000,
+  10: 5900,
+  11: 7200,
+  12: 8400,
+  13: 10000,
+  14: 11500,
+  15: 13000,
+  16: 15000,
+  17: 18000,
+  18: 20000,
+  19: 22000,
+  20: 25000,
+  21: 33000,
+  22: 41000,
+  23: 50000,
+  24: 62000,
+  25: 75000,
+  26: 90000,
+  27: 105000,
+  28: 120000,
+  29: 135000,
+  30: 155000,
+};
+
 const EncounterMultipliers = [1, 1.5, 2, 2.5, 3, 5];
 
 export const getEncounterMultiplier = (

--- a/src/model/ChallengeRating.ts
+++ b/src/model/ChallengeRating.ts
@@ -87,6 +87,7 @@ export const getEncounterDifficulty = (
   monsters: BaseCharacter[],
   players: Character[],
 ): ENCOUNTER_DIFFICULTY => {
+  // TODO (churt): get better at typescript.
   const partyDifficultyXpThresholds: Record<
     keyof typeof ENCOUNTER_DIFFICULTY,
     number

--- a/src/model/ChallengeRating.ts
+++ b/src/model/ChallengeRating.ts
@@ -1,0 +1,37 @@
+// Credit to stack overflow - https://stackoverflow.com/a/71700658
+type Tuple<
+  T,
+  N extends number,
+  R extends readonly T[] = [],
+> = R["length"] extends N ? R : Tuple<T, N, readonly [T, ...R]>;
+
+type CharacterXpThresholdsByLevel = Tuple<number, 20>;
+enum DIFFICULTY {
+  easy,
+  medium,
+  hard,
+  deadly,
+}
+
+// TODO (churt): Maybe there is a formula? But the pattern didn't suggest it.
+export const CharacterLevelEncounterXpThresholdsByDiffulty: Record<
+  keyof typeof DIFFICULTY,
+  CharacterXpThresholdsByLevel
+> = {
+  easy: [
+    25, 50, 75, 125, 250, 300, 350, 450, 550, 600, 800, 1000, 1100, 1250, 1400,
+    1600, 2000, 2100, 2400, 2800,
+  ],
+  medium: [
+    50, 100, 150, 250, 500, 600, 750, 900, 1100, 1200, 1600, 2000, 2200, 2500,
+    2800, 3200, 3900, 4200, 4900, 5700,
+  ],
+  hard: [
+    75, 150, 225, 375, 750, 900, 1100, 1400, 1600, 1900, 2400, 3000, 3400, 3800,
+    4300, 4800, 5900, 6300, 7300, 8500,
+  ],
+  deadly: [
+    100, 200, 400, 500, 1100, 1400, 1700, 2100, 2400, 2800, 3600, 4500, 5100,
+    5700, 6400, 7200, 8800, 9500, 10900, 12700,
+  ],
+};

--- a/src/model/ChallengeRating.ts
+++ b/src/model/ChallengeRating.ts
@@ -95,32 +95,28 @@ export const getEncounterDifficulty = (
     easy: players.reduce(
       (accumulator, currentValue) =>
         accumulator +
-        CharacterLevelEncounterXpThresholdsByDiffulty.easy[
-        currentValue.level as number
-        ],
+        CharacterLevelEncounterXpThresholdsByDiffulty.easy[currentValue.level],
       0,
     ),
     medium: players.reduce(
       (accumulator, currentValue) =>
         accumulator +
         CharacterLevelEncounterXpThresholdsByDiffulty.medium[
-        currentValue.level as number
+          currentValue.level
         ],
       0,
     ),
     hard: players.reduce(
       (accumulator, currentValue) =>
         accumulator +
-        CharacterLevelEncounterXpThresholdsByDiffulty.hard[
-        currentValue.level as number
-        ],
+        CharacterLevelEncounterXpThresholdsByDiffulty.hard[currentValue.level],
       0,
     ),
     deadly: players.reduce(
       (accumulator, currentValue) =>
         accumulator +
         CharacterLevelEncounterXpThresholdsByDiffulty.deadly[
-        currentValue.level as number
+          currentValue.level
         ],
       0,
     ),

--- a/src/model/Character.js
+++ b/src/model/Character.js
@@ -12,6 +12,7 @@ export class Character {
     initiativeBonus = 0,
     armorClass = 0,
     maxHealth = 0,
+    level = 1,
   ) {
     this.docId = docId;
     this.name = name;
@@ -25,15 +26,15 @@ export class Character {
     this.initiativeBonus = initiativeBonus;
     this.armorClass = armorClass;
     this.maxHealth = maxHealth;
+    this.level = level;
   }
-
 }
 
 export const validateCharacter = (character) => {
   let validator = {};
   if (!character?.name || character?.name.trim() === "") {
-    validator.name = "Empty Name"
+    validator.name = "Empty Name";
   }
 
   return validator;
-}
+};

--- a/src/service/CharacterService.tsx
+++ b/src/service/CharacterService.tsx
@@ -1,15 +1,27 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import { collection, doc, query, where } from "firebase/firestore";
 import { firestore } from "./firebase";
-import { useFirestoreCollectionMutation, useFirestoreDocument, useFirestoreDocumentMutation, useFirestoreQuery } from "@react-query-firebase/firestore";
+import {
+  useFirestoreCollectionMutation,
+  useFirestoreDocument,
+  useFirestoreDocumentMutation,
+  useFirestoreQuery,
+} from "@react-query-firebase/firestore";
 import { Character } from "@model/Character";
-import { ButtonStatuses, LoadingButton } from "@components/Button/LoadingButton"
+import {
+  ButtonStatuses,
+  LoadingButton,
+} from "@components/Button/LoadingButton";
 
 export function useCharacter(characterDocId = "") {
   const ref = doc(firestore, "characters", characterDocId);
 
-  const campaignQuery = useFirestoreDocument(["singleCharacter", characterDocId], ref, {subscribe: true});
-  
+  const campaignQuery = useFirestoreDocument(
+    ["singleCharacter", characterDocId],
+    ref,
+    { subscribe: true },
+  );
+
   const { data, isLoading } = campaignQuery;
 
   const characterData = data?.data() || {};
@@ -26,92 +38,173 @@ export function useCharacter(characterDocId = "") {
     characterData.passivePerception,
     characterData.initiativeBonus,
     characterData.armorClass,
-    characterData.maxHealth
+    characterData.maxHealth,
+    characterData.level,
   );
 
   return { character, isLoading };
 }
 
-export const useAddCharacterButton = (newCharacter: Character, onClick: () => void, validate: () => boolean) => {
+export const useAddCharacterButton = (
+  newCharacter: Character,
+  onClick: () => void,
+  validate: () => boolean,
+) => {
   const ref = collection(firestore, "characters");
   const mutation = useFirestoreCollectionMutation(ref);
-  const [buttonStatus, setButtonStatus] = useState<ButtonStatuses>(ButtonStatuses.Idle);
+  const [buttonStatus, setButtonStatus] = useState<ButtonStatuses>(
+    ButtonStatuses.Idle,
+  );
 
-  const { name = "", player = "", campaignDocId = "", characterImageURL = "", backstory = "", className = "", dndBeyondURL = "", passivePerception = 0, initiativeBonus = 0, armorClass = 0, maxHealth = 0 } = newCharacter;
+  const {
+    name = "",
+    player = "",
+    campaignDocId = "",
+    characterImageURL = "",
+    backstory = "",
+    className = "",
+    dndBeyondURL = "",
+    passivePerception = 0,
+    initiativeBonus = 0,
+    armorClass = 0,
+    maxHealth = 0,
+  } = newCharacter;
 
   const handleClick = () => {
-
     const valid = validate();
     if (valid) {
-      mutation.mutate({ name, player, characterImageURL, backstory, className, dndBeyondURL, campaignDocId, passivePerception, initiativeBonus, armorClass, maxHealth })
+      mutation.mutate({
+        name,
+        player,
+        characterImageURL,
+        backstory,
+        className,
+        dndBeyondURL,
+        campaignDocId,
+        passivePerception,
+        initiativeBonus,
+        armorClass,
+        maxHealth,
+      });
     }
 
-    if (!mutation.error && valid){
-      setButtonStatus(mutation.status as ButtonStatuses)
+    if (!mutation.error && valid) {
+      setButtonStatus(mutation.status as ButtonStatuses);
 
       onClick();
     } else {
-      setButtonStatus(ButtonStatuses.Error as ButtonStatuses)
+      setButtonStatus(ButtonStatuses.Error as ButtonStatuses);
     }
-  }
+  };
 
   useEffect(() => {
-    const timer = setTimeout(() => setButtonStatus(ButtonStatuses.Idle), 2000)
+    const timer = setTimeout(() => setButtonStatus(ButtonStatuses.Idle), 2000);
     return () => {
-      clearTimeout(timer)
-    }
-  }, [buttonStatus])
+      clearTimeout(timer);
+    };
+  }, [buttonStatus]);
 
   return (
-    <LoadingButton color="success" size="large" isLoading={mutation.isLoading} status={buttonStatus} onClick={handleClick}>Save Character</LoadingButton>
+    <LoadingButton
+      color="success"
+      size="large"
+      isLoading={mutation.isLoading}
+      status={buttonStatus}
+      onClick={handleClick}
+    >
+      Save Character
+    </LoadingButton>
   );
-}
+};
 
-export const useUpdateCharacterButton = (newCharacter: Character, onClick: () => void, validate: () => boolean) => {
+export const useUpdateCharacterButton = (
+  newCharacter: Character,
+  onClick: () => void,
+  validate: () => boolean,
+) => {
   const npcs = collection(firestore, "characters");
   const ref = newCharacter.docId && doc(npcs, newCharacter.docId);
   const mutation = useFirestoreDocumentMutation(ref);
 
-  const [buttonStatus, setButtonStatus] = useState<ButtonStatuses>(ButtonStatuses.Idle);
+  const [buttonStatus, setButtonStatus] = useState<ButtonStatuses>(
+    ButtonStatuses.Idle,
+  );
 
-  const { name = "", player = "", campaignDocId = "", characterImageURL = "", backstory = "", className = "", dndBeyondURL = "", docId, passivePerception = 0, initiativeBonus = 0, armorClass = 0, maxHealth = 0 } = newCharacter;
+  const {
+    name = "",
+    player = "",
+    campaignDocId = "",
+    characterImageURL = "",
+    backstory = "",
+    className = "",
+    dndBeyondURL = "",
+    docId,
+    passivePerception = 0,
+    initiativeBonus = 0,
+    armorClass = 0,
+    maxHealth = 0,
+    level = 1,
+  } = newCharacter;
 
   const handleClick = () => {
-
     const valid = validate();
     if (valid) {
-      mutation.mutate({ docId, name, player, characterImageURL, backstory, className, dndBeyondURL, campaignDocId, passivePerception, initiativeBonus, armorClass, maxHealth })
+      mutation.mutate({
+        docId,
+        name,
+        player,
+        characterImageURL,
+        backstory,
+        className,
+        dndBeyondURL,
+        campaignDocId,
+        passivePerception,
+        initiativeBonus,
+        armorClass,
+        maxHealth,
+        level,
+      });
     }
 
-    if (!mutation.error && valid){
-      setButtonStatus(mutation.status as ButtonStatuses)
+    if (!mutation.error && valid) {
+      setButtonStatus(mutation.status as ButtonStatuses);
 
       onClick();
     } else {
-      setButtonStatus(ButtonStatuses.Error as ButtonStatuses)
+      setButtonStatus(ButtonStatuses.Error as ButtonStatuses);
     }
-  }
+  };
 
   useEffect(() => {
-    const timer = setTimeout(() => setButtonStatus(ButtonStatuses.Idle), 2000)
+    const timer = setTimeout(() => setButtonStatus(ButtonStatuses.Idle), 2000);
     return () => {
-      clearTimeout(timer)
-    }
-  }, [buttonStatus])
+      clearTimeout(timer);
+    };
+  }, [buttonStatus]);
 
   return (
-    <LoadingButton color="success" size="large" isLoading={mutation.isLoading} status={buttonStatus} onClick={handleClick}>Update Character</LoadingButton>
+    <LoadingButton
+      color="success"
+      size="large"
+      isLoading={mutation.isLoading}
+      status={buttonStatus}
+      onClick={handleClick}
+    >
+      Update Character
+    </LoadingButton>
   );
-}
+};
 
 export function useCharacters() {
   const ref = query(collection(firestore, "characters"));
 
-  const characterQuery = useFirestoreQuery(["charactersList"], ref, { subscribe: true });
-  
+  const characterQuery = useFirestoreQuery(["charactersList"], ref, {
+    subscribe: true,
+  });
+
   const { data, isLoading, refetch } = characterQuery;
 
-  const charactersData = data?.docs.map(character => {
+  const charactersData = data?.docs.map((character) => {
     const {
       name,
       characterImageURL,
@@ -123,8 +216,9 @@ export function useCharacters() {
       passivePerception,
       initiativeBonus,
       armorClass,
-      maxHealth 
-    } = character.data()
+      maxHealth,
+      level,
+    } = character.data();
     return new Character(
       character.id,
       name,
@@ -137,7 +231,8 @@ export function useCharacters() {
       passivePerception,
       initiativeBonus,
       armorClass,
-      maxHealth 
+      maxHealth,
+      level,
     );
   });
 
@@ -145,13 +240,20 @@ export function useCharacters() {
 }
 
 export function useCampaignCharacters(campaignDocId: string) {
-  const ref = query(collection(firestore, "characters"), where("campaignDocId", "==", campaignDocId));
+  const ref = query(
+    collection(firestore, "characters"),
+    where("campaignDocId", "==", campaignDocId),
+  );
 
-  const characterQuery = useFirestoreQuery([`${campaignDocId}-campaignCharactersList`], ref, { subscribe: true });
-  
+  const characterQuery = useFirestoreQuery(
+    [`${campaignDocId}-campaignCharactersList`],
+    ref,
+    { subscribe: true },
+  );
+
   const { data, isLoading, refetch } = characterQuery;
 
-  const charactersData = data?.docs.map(character => {
+  const charactersData = data?.docs.map((character) => {
     const {
       name,
       characterImageURL,
@@ -163,8 +265,9 @@ export function useCampaignCharacters(campaignDocId: string) {
       passivePerception,
       initiativeBonus,
       armorClass,
-      maxHealth 
-    } = character.data()
+      maxHealth,
+      level,
+    } = character.data();
     return new Character(
       character.id,
       name,
@@ -177,9 +280,14 @@ export function useCampaignCharacters(campaignDocId: string) {
       passivePerception,
       initiativeBonus,
       armorClass,
-      maxHealth 
+      maxHealth,
+      level,
     );
   });
 
-  return { characters: campaignDocId && charactersData?.length ? charactersData : [], isLoading, refetch };
+  return {
+    characters: campaignDocId && charactersData?.length ? charactersData : [],
+    isLoading,
+    refetch,
+  };
 }

--- a/src/service/DndApiService.ts
+++ b/src/service/DndApiService.ts
@@ -9,6 +9,7 @@ const apiMonsterFields = [
   "dexterity",
   "armor_class",
   "hit_points",
+  "cr",
 ];
 
 type ApiMonsterResponse = {
@@ -18,11 +19,16 @@ type ApiMonsterResponse = {
   dexterity: number;
   armor_class: number;
   hit_points: number;
+  cr: number;
 };
 
-export type Monster = Omit<ApiMonsterResponse, "armor_class" | "hit_points"> & {
+export type Monster = Omit<
+  ApiMonsterResponse,
+  "armor_class" | "hit_points" | "cr"
+> & {
   armorClass: number;
   hitPoints: number;
+  challengeRating: number;
 };
 
 export const useDndApiMonsters = (
@@ -38,7 +44,8 @@ export const useDndApiMonsters = (
     queryKey: ["apiMonsters"],
     queryFn: () =>
       fetch(
-        `${GET_MONSTERS}?fields=${apiMonsterFields.join(",")}${officialOnly ? "&document__slug=wotc-srd" : ""
+        `${GET_MONSTERS}?fields=${apiMonsterFields.join(",")}${
+          officialOnly ? "&document__slug=wotc-srd" : ""
         }&limit=4000`,
       ).then((res) => res.json()),
   });
@@ -53,6 +60,7 @@ export const useDndApiMonsters = (
           hitPoints: monster.hit_points,
           name: monster.name,
           dexterity: monster.dexterity,
+          challengeRating: monster.cr,
         }))
         .sort((a: Monster, b: Monster) => a.name.localeCompare(b.name)) ?? [],
     isLoading,
@@ -71,7 +79,8 @@ export const useDndApiMonsterTypes = (
     queryKey: ["apiMonsters", "types"],
     queryFn: () =>
       fetch(
-        `${GET_MONSTERS}?fields=type${officialOnly ? "&document__slug=wotc-srd" : ""
+        `${GET_MONSTERS}?fields=type${
+          officialOnly ? "&document__slug=wotc-srd" : ""
         }&limit=4000`,
       ).then((res) => res.json()),
   });

--- a/src/views/CampaignViews/SingleCampaign/Tabs/InitiativeTracker/Combats.tsx
+++ b/src/views/CampaignViews/SingleCampaign/Tabs/InitiativeTracker/Combats.tsx
@@ -31,7 +31,6 @@ const Combats = ({ campaign, characters }: CombatsProps) => {
         health: character?.maxHealth,
         shouldShow: true,
         shouldShowHealthBar: true,
-        level: character.level,
       }) as CombatCharacter,
   );
 

--- a/src/views/CampaignViews/SingleCampaign/Tabs/InitiativeTracker/Combats.tsx
+++ b/src/views/CampaignViews/SingleCampaign/Tabs/InitiativeTracker/Combats.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import css from "./InitiativeTracker.module.scss"
+import css from "./InitiativeTracker.module.scss";
 import { TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
 import { Character } from "@model/Character";
 import { Button } from "@components/Button/Button";
@@ -11,16 +11,18 @@ import { Typography } from "@components/Typography/Typography";
 import { CombatEntryRow } from "./CombatEntryRow";
 
 type CombatsProps = {
-    campaign: Campaign,
-    characters: Character[]
-}
+  campaign: Campaign;
+  characters: Character[];
+};
 
 const Combats = ({ campaign, characters }: CombatsProps) => {
-    const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
 
-    const {combats} = useCampaignCombats(campaign.docId)
+  const { combats } = useCampaignCombats(campaign.docId);
 
-    const formattedCharacters = characters.map(character => ({
+  const formattedCharacters = characters.map(
+    (character) =>
+      ({
         name: character.name,
         initiativeBonus: character?.initiativeBonus,
         armorClass: character?.armorClass,
@@ -29,28 +31,39 @@ const Combats = ({ campaign, characters }: CombatsProps) => {
         health: character?.maxHealth,
         shouldShow: true,
         shouldShowHealthBar: true,
-    } as CombatCharacter))
+        level: character.level,
+      }) as CombatCharacter,
+  );
 
-    return (
-        <div className={css.initiativeTrackerContainer}>
-            <Button onClick={() => {setCreateModalOpen(true)}}>Create Encounter</Button>
-            <TableContainer style={{width: "500px", margin: "0 auto"}}>
-            <TableHead>
-                <TableRow>
-                    <TableCell width="20%"></TableCell>
-                    <TableCell width="80%"><Typography>Name</Typography></TableCell>
-                    <TableCell width="20%"></TableCell>
-                </TableRow>
-            </TableHead>
-            {
-                combats?.map(combat => 
-                    <CombatEntryRow combat={combat} />
-                )
-            }
-            </TableContainer>
-            <CreateCombatModal characters={formattedCharacters} isOpen={createModalOpen} onClose={() => setCreateModalOpen(false)} campaignId={campaign.docId} />
-        </div>
-    )
-}
+  return (
+    <div className={css.initiativeTrackerContainer}>
+      <Button
+        onClick={() => {
+          setCreateModalOpen(true);
+        }}
+      >
+        Create Encounter
+      </Button>
+      <TableContainer style={{ width: "500px", margin: "0 auto" }}>
+        <TableHead>
+          <TableRow>
+            <TableCell width="20%"></TableCell>
+            <TableCell width="80%">
+              <Typography>Name</Typography>
+            </TableCell>
+            <TableCell width="20%"></TableCell>
+          </TableRow>
+        </TableHead>
+        {combats?.map((combat) => <CombatEntryRow combat={combat} />)}
+      </TableContainer>
+      <CreateCombatModal
+        characters={formattedCharacters}
+        isOpen={createModalOpen}
+        onClose={() => setCreateModalOpen(false)}
+        campaignId={campaign.docId}
+      />
+    </div>
+  );
+};
 
-export default Combats
+export default Combats;

--- a/src/views/DMInitiative/DMInitiative.module.scss
+++ b/src/views/DMInitiative/DMInitiative.module.scss
@@ -1,109 +1,107 @@
 @import "src/sass_utils";
 
 .initiativeTrackerContainer {
-    margin: 0 auto;
-    max-width: 1096px;
-    flex-shrink: 0;
+  margin: 0 auto;
+  max-width: 1096px;
+  flex-shrink: 0;
 
-    .bottonsContainer {
-        position: fixed;
-        display: flex;
-        column-gap: 8px;
-        bottom: 16px;
-        right: 16px;
-        z-index: 100;
+  .bottonsContainer {
+    position: fixed;
+    display: flex;
+    column-gap: 8px;
+    bottom: 16px;
+    right: 16px;
+    z-index: 100;
+  }
+
+  .topButtonsRow {
+    display: flex;
+    justify-content: space-between;
+    overflow: visible;
+    padding-top: 8px;
+  }
+
+  .active {
+    color: black;
+    background-color: #3b321a;
+  }
+
+  .tableCell {
+    display: flex;
+    color: white;
+    column-gap: 16px;
+    align-items: center;
+    width: 100%;
+  }
+
+  .nameCell {
+    display: grid;
+    grid-template-columns: 1fr;
+    column-gap: 8px;
+    width: 100%;
+    align-items: center;
+  }
+
+  .identifier {
+    display: flex;
+    column-gap: 8px;
+    .avatar {
+      z-index: 1;
     }
+  }
 
-    .topButtonsRow {
-        display: flex;
-        justify-content: space-around;
-        overflow: visible;
-        padding-top: 8px;
+  .randomIcon {
+    &:hover {
+      cursor: pointer;
+      opacity: 0.8;
     }
+  }
 
-    .active {
-        color: black;
-        background-color: #3b321a;
-    }
+  .healthCell {
+    display: flex;
+  }
 
-    .tableCell {
-        display: flex;
-        color: white;
-        column-gap: 16px;
-        align-items: center;
-        width: 100%;
-    }
+  .healthCounterContainer {
+    background-color: black;
+    opacity: 0.9;
+    border-radius: 16px;
+    width: 80px;
+    text-align: center;
+    padding: 16px;
 
-    .nameCell {
-        display: grid;
-        grid-template-columns: 1fr;
-        column-gap: 8px;
-        width: 100%;
-        align-items: center;
-    }
+    .counterButtons {
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
+      padding-top: 8px;
 
-    .identifier {
-        display: flex;
-        column-gap: 8px;
-        .avatar {
-            z-index: 1;
-        }
-    }
+      .plus {
+        color: green;
 
-    .randomIcon {
         &:hover {
-            cursor: pointer;
-            opacity: 0.8;
+          opacity: 0.8;
+          cursor: pointer;
         }
-    }
+      }
+      .minus {
+        color: red;
 
-    .healthCell {
-        display: flex;
-    }
-
-    .healthCounterContainer {
-        background-color: black;
-        opacity: 0.9;
-        border-radius: 16px;
-        width: 80px;
-        text-align: center;
-        padding: 16px;
-
-        .counterButtons {
-            display: flex;
-            justify-content: space-around;
-            align-items: center;
-            padding-top: 8px;
-
-            .plus {
-
-                color: green;
-                
-                &:hover {
-                    opacity: 0.8;
-                    cursor: pointer;
-                }
-            }
-            .minus {
-
-                color: red;
-
-                &:hover {
-                    opacity: 0.8;
-                    cursor: pointer;
-                }
-            }
+        &:hover {
+          opacity: 0.8;
+          cursor: pointer;
         }
+      }
     }
+  }
 }
 
 .picker {
-    background-color: $dark;
-    border-width: 1px;
-    //border-style: solid;
-    border-radius: 5px;
-    color: $primary;
-    border-color: $primary;
-    box-shadow: none;
-    text-align: center;
+  background-color: $dark;
+  border-width: 1px;
+  //border-style: solid;
+  border-radius: 5px;
+  color: $primary;
+  border-color: $primary;
+  box-shadow: none;
+  text-align: center;
 }

--- a/src/views/DMInitiative/index.tsx
+++ b/src/views/DMInitiative/index.tsx
@@ -110,6 +110,7 @@ const DMInitiative = () => {
     handleUpdate({ ...combat, currentTurnIndex: newNextTurn }, removedList);
   };
 
+  // TODO: do this properly using types for safety. Maybe a better signifier? What about npcs?
   const encounterDiffulty = getEncounterDifficulty(
     list.filter((character) => !character?.playerDocId),
     list.filter((character) => character?.playerDocId),

--- a/src/views/DMInitiative/index.tsx
+++ b/src/views/DMInitiative/index.tsx
@@ -14,6 +14,56 @@ import { useCampaignCharacters } from "@services/CharacterService";
 import { getCombatURL } from "./utils";
 import CopyButton from "@components/Button/ReusableButtons/CopyButton";
 import ResourceDrawer from "@views/DMInitiative/components/ResourceDrawer";
+import LinearProgress from "@mui/material/LinearProgress";
+import {
+  ENCOUNTER_DIFFICULTY,
+  getEncounterDifficulty,
+} from "@model/ChallengeRating";
+import Box from "@mui/material/Box";
+
+type EncounterDiffultyProgressProps = {
+  difficulty: ENCOUNTER_DIFFICULTY;
+};
+
+const EncounterDiffultyProgress = ({
+  difficulty,
+}: EncounterDiffultyProgressProps) => {
+  let hint = "easy";
+  let color: "success" | "secondary" | "warning" | "error" = "success";
+
+  if (difficulty === ENCOUNTER_DIFFICULTY.medium) {
+    hint = "warning";
+    color = "warning";
+  }
+  if (difficulty === ENCOUNTER_DIFFICULTY.hard) {
+    hint = "hard";
+    color = "error";
+  }
+  if (difficulty === ENCOUNTER_DIFFICULTY.deadly) {
+    hint = "deadly";
+    color = "error";
+  }
+
+  return (
+    <Box sx={{ width: "25%" }}>
+      <Box sx={{ display: "flex", alignItems: "center" }}>
+        <Box sx={{ width: "100%" }}>
+          <LinearProgress
+            variant="determinate"
+            value={(difficulty + 1) * 25}
+            color={color}
+          />
+        </Box>
+        <Box sx={{ minWidth: 35, pl: 2 }}>
+          <Typography color="light" size="small" weight="bolder">
+            {hint}
+          </Typography>
+        </Box>
+      </Box>
+      <Typography>Difficulty</Typography>
+    </Box>
+  );
+};
 
 const DMInitiative = () => {
   const { combatId, campaignId = "" } = useParams();
@@ -38,7 +88,7 @@ const DMInitiative = () => {
       : combat.currentTurnIndex + 1;
 
   const handleUpdate = (combat: Combat, overrideCharacterArray = list) => {
-    console.log(overrideCharacterArray.filter(item => !item?.playerDocId))
+    console.log(overrideCharacterArray.filter((item) => !item?.playerDocId));
     updateInitiative({
       ...combat,
       combatCharacterArray: overrideCharacterArray,
@@ -60,6 +110,11 @@ const DMInitiative = () => {
     handleUpdate({ ...combat, currentTurnIndex: newNextTurn }, removedList);
   };
 
+  const encounterDiffulty = getEncounterDifficulty(
+    list.filter((character) => !character?.playerDocId),
+    list.filter((character) => character?.playerDocId),
+  );
+
   return (
     <div className={css.initiativeTrackerContainer}>
       <div className={css.topButtonsRow}>
@@ -74,7 +129,7 @@ const DMInitiative = () => {
           </Typography>
         </CopyButton>
         <Typography size={"xtraLarge"}>{combat.name}</Typography>
-        <div />
+        <EncounterDiffultyProgress difficulty={encounterDiffulty} />
       </div>
       <TableContainer>
         <TableHead>

--- a/src/views/DMInitiative/index.tsx
+++ b/src/views/DMInitiative/index.tsx
@@ -113,7 +113,7 @@ const DMInitiative = () => {
   // TODO: do this properly using types for safety. Maybe a better signifier? What about npcs?
   const encounterDiffulty = getEncounterDifficulty(
     list.filter((character) => !character?.playerDocId),
-    list.filter((character) => character?.playerDocId),
+    characters,
   );
 
   return (


### PR DESCRIPTION
This adds a bit more than I wanted - and it is a bit hacky due to our current lack of overlap on some concepts but it works nonetheless. Let me know your thoughts.

## Main changes:

1. Track PC levels and NPC levels (doesn't really work with NPCs added to combats yet).Modal updated.
2. Track XP for custom monsters. Modal updated.
3. Pull CR for monsters in API.
4. Calculations from dnd 5e for encounter building.
5. Added LinearProgress with hint that updates as enemies are added/removed.

## Screenshots


![Screenshot_4](https://github.com/ajones119/BarrysNotesOnBarovia/assets/4443527/2247c0df-640b-4a9c-b4fb-c040c12c23b4)

![Screenshot_5](https://github.com/ajones119/BarrysNotesOnBarovia/assets/4443527/1289d3c6-ff9c-4595-bbd7-5977317316fd)

![Screenshot_8](https://github.com/ajones119/BarrysNotesOnBarovia/assets/4443527/a6c32867-52dd-4ff7-bf1c-578b7000c879)

![Screenshot_9](https://github.com/ajones119/BarrysNotesOnBarovia/assets/4443527/acf1f357-8a66-463a-887a-95993ebe2344)
